### PR TITLE
Fix port for healthcheck

### DIFF
--- a/doc/Public_API.md
+++ b/doc/Public_API.md
@@ -14,9 +14,11 @@ $ curl -s  http://localhost:8080/platform/api/modules/health/live | jq .
 Could be used to setup probes on kubernetes or docker-compose. 
 
 #### docker-compose probe setup
+
+
 ```yaml
 healthcheck:
-    test: ["CMD-SHELL", "curl --fail http://localhost:${PLATFORM_LISTENING_PORT:-8080}/platform/api/modules/health/live"]
+    test: ["CMD-SHELL", "curl --fail http://localhost:${CDK_LISTENING_PORT:-8080}/platform/api/modules/health/live"]
     interval: 10s
     start_period: 120s # Leave time for the psql init scripts to run
     timeout: 5s
@@ -24,11 +26,22 @@ healthcheck:
 ```
 
 #### Kubernetes liveness probe
+
+Port configuration
+
+```yaml
+ports:
+  - containerPort: 8080
+    protocol: TCP
+    name: httpprobe 
+```
+Probe configuration
+
 ```yaml
 livenessProbe:
     httpGet:
         path: /platform/api/modules/health/live
-        port: http # Adapt based on PLATFORM_LISTENING_PORT
+        port: httpprobe
     initialDelaySeconds: 5
     periodSeconds: 10
     timeoutSeconds: 5
@@ -62,11 +75,20 @@ $ curl -s  http://localhost:8080/platform/api/modules/health/ready | jq .
 ```
 
 #### Kubernetes startup probe
+
+Port configuration
+
+```yaml
+ports:
+  - containerPort: 8080
+    protocol: TCP
+    name: httpprobe 
+
 ```yaml
 startupProbe:
     httpGet:
         path: /platform/api/modules/health/ready
-        port: http # Adapt based on PLATFORM_LISTENING_PORT
+        port: httpprobe
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5

--- a/doc/Public_API.md
+++ b/doc/Public_API.md
@@ -16,7 +16,7 @@ Could be used to setup probes on kubernetes or docker-compose.
 #### docker-compose probe setup
 ```yaml
 healthcheck:
-    test: ["CMD-SHELL", "curl --fail http://localhost/platform/api/modules/health/live"]
+    test: ["CMD-SHELL", "curl --fail http://localhost:${PLATFORM_LISTENING_PORT:-8080}/platform/api/modules/health/live"]
     interval: 10s
     start_period: 120s # Leave time for the psql init scripts to run
     timeout: 5s
@@ -28,7 +28,7 @@ healthcheck:
 livenessProbe:
     httpGet:
         path: /platform/api/modules/health/live
-        port: http
+        port: http # Adapt based on PLATFORM_LISTENING_PORT
     initialDelaySeconds: 5
     periodSeconds: 10
     timeoutSeconds: 5
@@ -66,7 +66,7 @@ $ curl -s  http://localhost:8080/platform/api/modules/health/ready | jq .
 startupProbe:
     httpGet:
         path: /platform/api/modules/health/ready
-        port: http
+        port: http # Adapt based on PLATFORM_LISTENING_PORT
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5

--- a/example-local/docker-compose.yml
+++ b/example-local/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl --fail http://localhost/platform/api/modules/health/live"
+          "curl --fail http://localhost:${PLATFORM_LISTENING_PORT:-8080}/platform/api/modules/health/live"
         ]
       interval: 30s
       start_period: 120s # Leave time for the psql init scripts to run

--- a/example-local/docker-compose.yml
+++ b/example-local/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl --fail http://localhost:${PLATFORM_LISTENING_PORT:-8080}/platform/api/modules/health/live"
+          "curl --fail http://localhost:${CDK_LISTENING_PORT:-8080}/platform/api/modules/health/live"
         ]
       interval: 30s
       start_period: 120s # Leave time for the psql init scripts to run

--- a/example-sso-ldap/docker-compose.yml
+++ b/example-sso-ldap/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -sq --fail http://localhost/platform/api/modules/health/live"
+          "curl -sq --fail http://localhost:${PLATFORM_LISTENING_PORT:-8080}/platform/api/modules/health/live"
         ]
       interval: 30s
       start_period: 120s # Leave time for the psql init scripts to run

--- a/example-sso-ldap/docker-compose.yml
+++ b/example-sso-ldap/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -sq --fail http://localhost:${PLATFORM_LISTENING_PORT:-8080}/platform/api/modules/health/live"
+          "curl -sq --fail http://localhost:${CDK_LISTENING_PORT:-8080}/platform/api/modules/health/live"
         ]
       interval: 30s
       start_period: 120s # Leave time for the psql init scripts to run


### PR DESCRIPTION
Given that `PLATFORM_LISTENING_PORT` - soon to be replaced with `CDK_LISTENING_PORT` defaults to 8080, the healthcheck need to be updated to reflect that change.

PS: unsure if `CMD-SHELL` will use the env var substitution, but I think it does.