### PR TITLE
gw2.5 release

### DIFF
--- a/quick-start.yml
+++ b/quick-start.yml
@@ -102,7 +102,7 @@ services:
         condition: service_healthy
   
   conduktor-data-generator:
-    image: conduktor/conduktor-data-generator:0.2
+    image: conduktor/conduktor-data-generator:0.3
     container_name: conduktor-data-generator
     environment:
       KAFKA_BOOTSTRAP_SERVERS: conduktor-gateway:6969

--- a/quick-start.yml
+++ b/quick-start.yml
@@ -86,7 +86,7 @@ services:
       start_period: 5s
   
   conduktor-gateway:
-    image: conduktor/conduktor-gateway:2.3.0
+    image: conduktor/conduktor-gateway:2.5.0
     hostname: conduktor-gateway
     container_name: conduktor-gateway
     environment:


### PR DESCRIPTION
We will need to do this again once the ARM variant is available
as part of that point is to remove the warning on start

> The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested