### PR TITLE
Docker compose attribute removal

### DIFF
--- a/quick-start.yml
+++ b/quick-start.yml
@@ -10,7 +10,6 @@
 #   to deploy on Kubernetes via Helm, or AWS using Cloudformation.
 ####################################################################################################
 
-version: '3.8'
 
 services:  
 


### PR DESCRIPTION
**Problem:**

When running the Console quick start, a warning is generated by docker:

```
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```


**Solution:**

I have updated the docker compose file to remove the version attribute.