### PR TITLE
bump data gen with correct encryption config

### DIFF
--- a/quick-start.yml
+++ b/quick-start.yml
@@ -129,7 +129,7 @@ services:
   # As this is a get started, we want to bring some life to the cluster to demonstrate the value of Conduktor.
   # This is totally optional and only used for this purpose. Do not use it in production.
   conduktor-data-generator:
-    image: conduktor/conduktor-data-generator:0.5
+    image: conduktor/conduktor-data-generator:0.6
     container_name: conduktor-data-generator
     environment:
       KAFKA_BOOTSTRAP_SERVERS: conduktor-gateway:6969


### PR DESCRIPTION
Using old config, now uses correct config to try improve stability. Is still an unsolved issue where you have to click and reapply the encryption interceptor some of the time for it to work.