### PR TITLE
Chore: Update failing health checks

### DIFF
--- a/quick-start.yml
+++ b/quick-start.yml
@@ -68,7 +68,7 @@ services:
       POSTGRES_PASSWORD: "change_me"
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U conduktor -d conduktor-console"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -88,7 +88,7 @@ services:
       POSTGRES_PASSWORD: "change_me"
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U conduktor -d conduktor-sql"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Previous health checks were failing with `FATAL:  role "root" does not exist`. Seems there have been some change that broke the health checks

-  Modified the healthcheck command for the `conduktor-console` database to include the database name and user (`pg_isready -U conduktor -d conduktor-console`).

- Modified the healthcheck command for the `conduktor-sql` database to include the database name and user (`pg_isready -U conduktor -d conduktor-sql`).